### PR TITLE
firebase storage 다운로드 기능 추가

### DIFF
--- a/src/main/java/com/realworld/feature/file/controller/FileController.java
+++ b/src/main/java/com/realworld/feature/file/controller/FileController.java
@@ -5,6 +5,7 @@ import com.realworld.feature.file.service.FileNameGenerator;
 import com.realworld.feature.file.service.StorageService;
 import com.realworld.global.code.SuccessCode;
 import com.realworld.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
@@ -63,6 +64,14 @@ public class FileController {
                 SuccessCode.INSERT_SUCCESS.getStatus(), SuccessCode.INSERT_SUCCESS.getMessage());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(fileUploadResponse);
+    }
+
+    @GetMapping("/{fileId}")
+    public void getFile(@AuthenticationPrincipal User user,
+                        @PathVariable String fileId,
+                        HttpServletResponse response) throws IOException {
+
+        cloudStorageService.getFile(fileId, response.getOutputStream());
     }
 
     @DeleteMapping("/{fileId}")

--- a/src/main/java/com/realworld/feature/file/domain/File.java
+++ b/src/main/java/com/realworld/feature/file/domain/File.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.UUID;
 
@@ -47,9 +46,15 @@ public class File {
         this.size = size;
     }
 
+    public String getPath() {
+        return "https://photocard.site/api/v1/file/" + getId();
+    }
+
     public String getThumbnailPath() {
-        return isHasThumbnail() ? (StringUtils.substringBefore(this.path, this.id.toString())
-                + ThumbnailImageGenerator.THUMBNAIL_PREFIX + this.id) : "";
+        //  return isHasThumbnail() ? (StringUtils.substringBefore(this.path, this.id.toString())
+        //      + ThumbnailImageGenerator.THUMBNAIL_PREFIX + this.id) : "";
+
+        return isHasThumbnail() ? "https://photocard.site/api/v1/file/" + ThumbnailImageGenerator.THUMBNAIL_PREFIX + getId() : "";
     }
 
     public void updateId(UUID id) {

--- a/src/main/java/com/realworld/feature/file/service/CloudStorageService.java
+++ b/src/main/java/com/realworld/feature/file/service/CloudStorageService.java
@@ -17,6 +17,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -84,6 +85,10 @@ public class CloudStorageService implements StorageService {
         return file;
     }
 
+    @Override
+    public void getFile(String id, OutputStream os) {
+        fireBaseService.getFile(id, os);
+    }
 
     @Override
     public void delete(String userId, String fileId) {

--- a/src/main/java/com/realworld/feature/file/service/LocalStorageService.java
+++ b/src/main/java/com/realworld/feature/file/service/LocalStorageService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -75,5 +76,10 @@ public class LocalStorageService implements StorageService {
 
         // TODO: 파일 삭제는 직접ㅎㅎ
         fileJpaEntity.ifPresent(fileRepository::delete);
+    }
+
+    @Override
+    public void getFile(String id, OutputStream os) {
+        // 파일 가져오기
     }
 }

--- a/src/main/java/com/realworld/feature/file/service/StorageService.java
+++ b/src/main/java/com/realworld/feature/file/service/StorageService.java
@@ -3,9 +3,12 @@ package com.realworld.feature.file.service;
 import com.realworld.feature.file.domain.File;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 
 public interface StorageService {
     File upload(InputStream inputStream, String userId, File file);
 
     void delete(String userId, String fileId);
+
+    void getFile(String id, OutputStream os);
 }

--- a/src/main/java/com/realworld/infra/firebase/FireBaseService.java
+++ b/src/main/java/com/realworld/infra/firebase/FireBaseService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 
 @Service
 public class FireBaseService {
@@ -19,6 +20,13 @@ public class FireBaseService {
         Blob blob = bucket.create(key, inputStream, contentType);
 
         return blob.getMediaLink();
+    }
+
+    public void getFile(String key, OutputStream os) {
+        Bucket bucket = StorageClient.getInstance().bucket(fireBaseStorage);
+
+        Blob blob = bucket.get(key);
+        blob.downloadTo(os);
     }
 
     public void deleteFireBaseBucket(String key) {


### PR DESCRIPTION
File 객체에서 getPath 할 때 url 세팅하긴 했는 데 프론트에서 baseUrl 을 가지고 있으니까
클라이언트단에서 파일아이디 앞에 'https://photocard.site/api/v1/file/' 을 붙이는 게 더 좋을 거 같아요~~
env 파일에 저장한다면, 나중에 url이 바뀔 때 쉽게 반영되니까 수정하기도 더 좋을 것 같구요